### PR TITLE
Add travis and scruntinizer configs. Fix test cases for Travis. Make …

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,0 +1,9 @@
+inherit: true
+
+checks:
+  php:
+    code_rating: true
+    duplication: true
+
+filter:
+  paths: [code/*, tests/*]

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,30 @@
+# See https://github.com/silverstripe-labs/silverstripe-travis-support for setup details
+
+language: php 
+
+php: 
+ - 5.3
+
+env:
+  matrix:
+    - DB=MYSQL CORE_RELEASE=3.1
+
+matrix:
+  include:
+    - php: 5.3
+      env: DB=PGSQL CORE_RELEASE=3.1
+    - php: 5.4
+      env: DB=MYSQL CORE_RELEASE=3.2
+    - php: 5.5
+      env: DB=MYSQL CORE_RELEASE=3.2
+    - php: 5.6
+      env: DB=MYSQL CORE_RELEASE=3
+
+before_script:
+ - phpenv rehash
+ - git clone git://github.com/silverstripe-labs/silverstripe-travis-support.git ~/travis-support
+ - php ~/travis-support/travis_setup.php --source `pwd` --target ~/builds/ss
+ - cd ~/builds/ss
+
+script: 
+ - phpunit silverstripe-authorized-redirects/tests/

--- a/code/dataobjects/Authorization.php
+++ b/code/dataobjects/Authorization.php
@@ -117,6 +117,10 @@ class Authorization extends DataObject {
 		return true;
 	}
 
+	/**
+	 * Generates the One Time code that is passed to the redirect URL as GET param ott
+	 * Supports extension via extendGenerateOneTime, with a max token length of 255
+	 */
 	public function generateOneTime() {
 		$randomGen = new RandomGenerator();
 		$random = substr($randomGen->randomToken(), 0, 10);
@@ -244,9 +248,11 @@ class Authorization extends DataObject {
 	static public function generateClientKey($use_cookie = true) {
 		if ($use_cookie) {
 			if (!($client = Cookie::get(Config::inst()->get('Authorization', 'cookie_name')))) {
+				//we use SS_Datetime here as it supports mocking us we can unit test here reliably
+				$dataTime = SS_Datetime::now()->Format(DATE_ATOM);
 				// Note: _mkto_trk is not always available, but that's okay! It will return null when it's not.
 				// It's not vital, but when it exists, it adds an additional level of uniqueness to the hash.
-				$client = sha1(microtime() . '|' . $_SERVER['REMOTE_ADDR'] . '|' . Cookie::get('_mkto_trk'));
+				$client = sha1($dataTime . '|' . $_SERVER['REMOTE_ADDR'] . '|' . Cookie::get('_mkto_trk'));
 			}
 			// Set cookie every time (even when it's already set).
 			// This allows them 14 days of pure inactivity before the token resets.

--- a/code/dataobjects/Authorization.php
+++ b/code/dataobjects/Authorization.php
@@ -249,10 +249,10 @@ class Authorization extends DataObject {
 		if ($use_cookie) {
 			if (!($client = Cookie::get(Config::inst()->get('Authorization', 'cookie_name')))) {
 				//we use SS_Datetime here as it supports mocking us we can unit test here reliably
-				$dataTime = SS_Datetime::now()->Format(DATE_ATOM);
+				$dataTime = new DateTime(SS_Datetime::now()->Format(DATE_ATOM));
 				// Note: _mkto_trk is not always available, but that's okay! It will return null when it's not.
 				// It's not vital, but when it exists, it adds an additional level of uniqueness to the hash.
-				$client = sha1($dataTime . '|' . $_SERVER['REMOTE_ADDR'] . '|' . Cookie::get('_mkto_trk'));
+				$client = sha1($dataTime->getTimestamp() . '|' . $_SERVER['REMOTE_ADDR'] . '|' . Cookie::get('_mkto_trk'));
 			}
 			// Set cookie every time (even when it's already set).
 			// This allows them 14 days of pure inactivity before the token resets.

--- a/code/pages/AuthorizedPage.php
+++ b/code/pages/AuthorizedPage.php
@@ -125,9 +125,10 @@ class AuthorizedPage_Controller extends Page_Controller {
 	}
 
 	public function new_authorization() {
+		// < 5.5 compat, as empty() only supports vars
 		$postVars = $this->request->postVars();
-		$data = $this->data();
-		if (empty($postVars) || !$data) return $this->redirectBack();
+		if (empty($postVars) || !$this->data()) return $this->redirectBack();
+		unset($postVars); //clear var as we're using the method
 
 		// We will create an authorization EVEN IF the email is not allowed.
 		// This allows us to see who requested access, even if they're not allowed.

--- a/tests/Authorized.yml
+++ b/tests/Authorized.yml
@@ -9,7 +9,7 @@ Authorization:
   Auth1:
     Email: test@email.com
     ClientInfo: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.73 Safari/537.36'
-    ClientKey: 7737fba2af70ce991edc9cabbb7d341aa45c81dd
+    ClientKey: c2f2045d15a91bff866ff8f57c48f6540ff26b1c
     AccessCode: 1353D210FA
     OneTimeCode: 1353D210FA
     EmailSent: 2015-12-11 14:44:09

--- a/tests/AuthorizedTest.php
+++ b/tests/AuthorizedTest.php
@@ -7,19 +7,20 @@
  */
 class AuthorizedTest extends SapphireTest {
 
-	static $fixture_file = 'authorized-redirects/tests/Authorized.yml';
+	protected static $fixture_file = 'Authorized.yml';
 
 	public function setUp() {
 		parent::setUp();
 
+		SS_Datetime::create()->set_mock_now('2015-01-01T00:00:00+11:00');
 		$_SERVER['HTTP_USER_AGENT'] = 'A TEST STRING';
 		$_SERVER['REMOTE_ADDR'] = '127.0.0.1';
 	}
 
 	public function testAbsoluteLink() {
 		$auth = $this->objFromFixture('Authorization', 'Auth1');
-
-		$this->assertEquals('http://ssbase.dev/authtesturl/?Email=test%40email.com&AccessCode=1353D210FA', $auth->AbsoluteLink(), $auth->AbsoluteLink());
+		$expected = 'authtesturl/?Email=test%40email.com&AccessCode=1353D210FA';
+		$this->assertTrue((strpos($auth->AbsoluteLink(), $expected) !== false));
 	}
 
 	public function testgetMenuTitle() {
@@ -38,7 +39,7 @@ class AuthorizedTest extends SapphireTest {
 		$authPage = $this->objFromFixture('AuthorizedPage', 'AuthPage1');
 		$Email = 'test@email.com';
 		$AccessCode = '1353D210FA';
-		$ClientKey = '7737fba2af70ce991edc9cabbb7d341aa45c81dd';
+		$ClientKey = 'c2f2045d15a91bff866ff8f57c48f6540ff26b1c';
 		$ClientInfo = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.73 Safari/537.36';
 
 		$this->assertEquals(0, Authorization::AuthorizationErrors($authPage, $Email, $AccessCode, $ClientKey, $ClientInfo));
@@ -50,7 +51,7 @@ class AuthorizedTest extends SapphireTest {
 
 		$Email = 'test@email.com';
 		$AccessCode = '1353D210FA';
-		$ClientKey = '7737fba2af70ce991edc9cabbb7d341aa45c81dd';
+		$ClientKey = 'c2f2045d15a91bff866ff8f57c48f6540ff26b1c';
 		$ClientInfo = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.73 Safari/537.36';
 
 		$this->assertEquals($auth, Authorization::Fetch($authPage, $Email, $AccessCode, $ClientKey, $ClientInfo));
@@ -58,7 +59,7 @@ class AuthorizedTest extends SapphireTest {
 
 	public function testgenerateClientKey() {
 
-		$this->assertEquals('4c43bb699d00f1bb635ccaabd6f0894c6cddf80b', Authorization::generateClientKey());
+		$this->assertEquals('277cae6d1271352d959d823b5de46644da100562', Authorization::generateClientKey());
 	}
 
 	public function testgenerateClientInfo() {

--- a/tests/AuthorizedTest.php
+++ b/tests/AuthorizedTest.php
@@ -59,7 +59,7 @@ class AuthorizedTest extends SapphireTest {
 
 	public function testgenerateClientKey() {
 
-		$this->assertEquals('277cae6d1271352d959d823b5de46644da100562', Authorization::generateClientKey());
+		$this->assertEquals('f57fa6a129a4c369157f521724ca24bf6a8e25fc', Authorization::generateClientKey());
 	}
 
 	public function testgenerateClientInfo() {


### PR DESCRIPTION
…Authorization::generateClientKey testable
- Add docblock on generateOneTime
- Fix some test case values. And support for sub 5.5 php
- Fix test not tolerating different urls
- Change Authorization::generateClientKey to use SS_Datetime, so we can mock the datetime
- Remove test against SilverStripe master branch for now as we have composer conflicts
